### PR TITLE
BUG-902: Make template authorwidget capable

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ on console.
 
 ## Changes
 
+### 1.4.2
+* BUG-902: Make template authorwidget capable
+
 ### 1.4.1
 * ZON-4509: Use relative font sizes (rem) in CSS
 

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -4,7 +4,7 @@ Theme URI:        https://github.com/ZeitOnline/zon-blogs-theme-child-freitext
 Author:           ZEIT ONLINE, Palasthotel
 Author URI:       http://www.zeit.de
 Description:      Theme for the Zeit Online Freitext Blog 2018
-Version:          1.4.1
+Version:          1.4.2
 Template:         zon-blogs-theme
 Text Domain:      zb-child
 License:          GPL-3.0+

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI:        https://github.com/ZeitOnline/zon-blogs-theme-child-freitext
 Author:           ZEIT ONLINE, Palasthotel
 Author URI:       http://www.zeit.de
 Description:      Theme for the Zeit Online Freitext Blog 2018
-Version:          1.4.1
+Version:          1.4.2
 Template:         zon-blogs-theme
 Text Domain:      zb-child
 License:          GPL-3.0+

--- a/template-parts/content-single.php
+++ b/template-parts/content-single.php
@@ -21,7 +21,7 @@
 	</header><!-- .entry-header -->
   <div class="entry-content">
     <?php
-      zb_render_content_with_ads( apply_filters( 'the_content', get_the_content() ), zb_get_meta( 'zb_medium_rectangle_paragraph', 1 ) );
+      zb_render_content_with_ads( apply_filters( 'the_content', get_the_content() ), zb_get_meta( 'zb_medium_rectangle_paragraph', 1 ), zb_get_meta( 'zb_author_box_paragraph', 1 ), zb_get_meta( 'zb_author_box' ), zb_get_meta( 'zb_authorbox_fullwidth' ) );
     ?>
   </div><!-- .entry-content -->
 


### PR DESCRIPTION
We accidently activated the author widget in freitext and now need to make it work as expected by changing the theme.

Before: Add an author info to your user and add the author widget to the article widget area. In a post the input for the widget's position does not work, hence it's not changing the position:

After: The widget can be placed after every paragraph w/ the following rules: min. 2nd paragraph and not in the same paragraph as an ad, if so, it falls back to display the author widget at the article bottom.